### PR TITLE
licenseform 手当取得　修正

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -13,6 +13,7 @@ class Admin::ProjectsController < ApplicationController
   def new
     @project = Project.new
     @users = User.all
+    @licenses = License.where.not(title: "隊長手当").where.not(title: "運転手当").where.not(title: "出張手当").where.not(title: "規制手当")
   end
 
   def create
@@ -58,6 +59,7 @@ class Admin::ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     @users = User.all
     @members = ProjectUser.where(project: params[:id])
+    @licenses = License.where.not(title: "隊長手当").where.not(title: "運転手当").where.not(title: "出張手当").where.not(title: "規制手当")
   end
 
   def update

--- a/app/views/admin/projects/_project_license_fields.html.erb
+++ b/app/views/admin/projects/_project_license_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-fields mb-3 row">
   <div class="col-8">
-    <%= f.collection_select :license_id, License.all, :id, :title, {prompt: "資格を選択してください"}, {class: 'form-control'} %>
+    <%= f.collection_select :license_id, @licenses, :id, :title, {prompt: "資格を選択してください"}, {class: 'form-control'} %>
   </div>
   <div class="col-4">
     <%= link_to_remove_association f do %>


### PR DESCRIPTION
project作成の際、資格を追加欄で隊長手当・運転手当・出張手当・規制手当を追加してしまうと重複して選択されてしまうことになる。ので、隊長手当・運転手当・出張手当・規制手当　以外を取得した